### PR TITLE
webSocket

### DIFF
--- a/src/app/core/api/webSocketApi/web-socket-api.spec.ts
+++ b/src/app/core/api/webSocketApi/web-socket-api.spec.ts
@@ -1,0 +1,189 @@
+import { TestBed } from '@angular/core/testing';
+import { webSocketEnvironment } from '../../../../environments/environment';
+import { TokenState } from '../../services/token.state';
+import { WebSocketApi } from './web-socket-api';
+import {
+  WebSocketCloseCode,
+  WebSocketSyncAckResponse,
+  WebSocketSyncCompletedResponse,
+  WebSocketSyncRequest,
+} from './webSocket.model';
+
+describe('WebSocketApi', () => {
+  let service: WebSocketApi;
+  let tokenStateMock: jasmine.SpyObj<TokenState>;
+  let originalWebSocket: any;
+  let wsInstance: any;
+
+  beforeEach(() => {
+    tokenStateMock = jasmine.createSpyObj('TokenState', ['getAccessToken']);
+    TestBed.configureTestingModule({
+      providers: [
+        WebSocketApi,
+        { provide: TokenState, useValue: tokenStateMock },
+      ],
+    });
+    service = TestBed.inject(WebSocketApi);
+    // Mock global WebSocket
+    const g: any = globalThis as any;
+    originalWebSocket = g.WebSocket;
+    wsInstance = {
+      send: jasmine.createSpy('send'),
+      close: jasmine.createSpy('close'),
+      readyState: 1,
+    };
+    g.WebSocket = jasmine.createSpy('WebSocket').and.returnValue(wsInstance);
+  });
+
+  afterEach(() => {
+    (globalThis as any).WebSocket = originalWebSocket;
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should error if no access token', (done) => {
+    tokenStateMock.getAccessToken.and.returnValue(null);
+    service.bulkSyncWebSocket({ changes: [] }).subscribe({
+      error: (err) => {
+        expect(err.message).toContain('No access token');
+        done();
+      },
+    });
+  });
+
+  it('should error if no WebSocket URL', (done) => {
+    tokenStateMock.getAccessToken.and.returnValue('token');
+    spyOnProperty(webSocketEnvironment, 'webSocketUrl', 'get').and.returnValue(
+      undefined,
+    );
+    service.bulkSyncWebSocket({ changes: [] }).subscribe({
+      error: (err) => {
+        expect(err.message).toContain('WebSocket URL not configured');
+        done();
+      },
+    });
+  });
+
+  it('should send request and handle ack/completed', (done) => {
+    tokenStateMock.getAccessToken.and.returnValue('token');
+    spyOnProperty(webSocketEnvironment, 'webSocketUrl', 'get').and.returnValue(
+      'ws://test',
+    );
+    const req: WebSocketSyncRequest = { changes: [] };
+    const ack: WebSocketSyncAckResponse = {
+      type: 'ack',
+      operation_id: '1',
+      status: 'started',
+      created_at: 'now',
+    };
+    const completed: WebSocketSyncCompletedResponse = {
+      type: 'completed',
+      operation_id: '1',
+      status: 'completed',
+      completed_at: 'now',
+      notifications: [],
+    };
+    const results: any[] = [];
+    service.bulkSyncWebSocket(req).subscribe({
+      next: (msg) => results.push(msg),
+      complete: () => {
+        expect(wsInstance.send).toHaveBeenCalledWith(JSON.stringify(req));
+        expect(results[0]).toEqual(ack);
+        expect(results[1]).toEqual(completed);
+        done();
+      },
+    });
+    wsInstance.onopen();
+    wsInstance.onmessage({ data: JSON.stringify(ack) });
+    wsInstance.onmessage({ data: JSON.stringify(completed) });
+  });
+
+  it('should error on invalid JSON', (done) => {
+    tokenStateMock.getAccessToken.and.returnValue('token');
+    spyOnProperty(webSocketEnvironment, 'webSocketUrl', 'get').and.returnValue(
+      'ws://test',
+    );
+    service.bulkSyncWebSocket({ changes: [] }).subscribe({
+      error: (err) => {
+        expect(err.message).toContain('Invalid JSON');
+        done();
+      },
+    });
+    wsInstance.onopen();
+    wsInstance.onmessage({ data: 'not-json' });
+  });
+
+  it('should error on WebSocket error', (done) => {
+    tokenStateMock.getAccessToken.and.returnValue('token');
+    spyOnProperty(webSocketEnvironment, 'webSocketUrl', 'get').and.returnValue(
+      'ws://test',
+    );
+    service.bulkSyncWebSocket({ changes: [] }).subscribe({
+      error: (err) => {
+        expect(err.message).toContain('WebSocket connection error');
+        done();
+      },
+    });
+    wsInstance.onerror();
+  });
+
+  it('should handle WebSocket close codes', (done) => {
+    tokenStateMock.getAccessToken.and.returnValue('token');
+    spyOnProperty(webSocketEnvironment, 'webSocketUrl', 'get').and.returnValue(
+      'ws://test',
+    );
+    const closeCodes = [
+      {
+        code: WebSocketCloseCode.MissingToken,
+        msg: 'Missing authentication token',
+      },
+      {
+        code: WebSocketCloseCode.InvalidToken,
+        msg: 'Invalid authentication token',
+      },
+      {
+        code: WebSocketCloseCode.InvalidPayload,
+        msg: 'Invalid request payload',
+      },
+      { code: WebSocketCloseCode.InternalError, msg: 'Internal server error' },
+      { code: 9999, msg: 'WebSocket closed with code: 9999' },
+    ];
+    let tested = 0;
+    closeCodes.forEach(({ code, msg }) => {
+      service.bulkSyncWebSocket({ changes: [] }).subscribe({
+        error: (err) => {
+          expect(err.message).toContain(msg);
+          tested++;
+          if (tested === closeCodes.length) done();
+        },
+      });
+      wsInstance.onclose({ code });
+    });
+  });
+
+  it('should complete on normal closure', (done) => {
+    tokenStateMock.getAccessToken.and.returnValue('token');
+    spyOnProperty(webSocketEnvironment, 'webSocketUrl', 'get').and.returnValue(
+      'ws://test',
+    );
+    service.bulkSyncWebSocket({ changes: [] }).subscribe({
+      complete: () => done(),
+    });
+    wsInstance.onclose({ code: WebSocketCloseCode.NormalClosure });
+  });
+
+  it('should close socket on disconnect', () => {
+    tokenStateMock.getAccessToken.and.returnValue('token');
+    spyOnProperty(webSocketEnvironment, 'webSocketUrl', 'get').and.returnValue(
+      'ws://test',
+    );
+    service.bulkSyncWebSocket({ changes: [] }).subscribe();
+    service.disconnect();
+    expect(wsInstance.close).toHaveBeenCalledWith(
+      WebSocketCloseCode.NormalClosure,
+    );
+    expect((service as any).socket).toBeNull();
+  });
+});

--- a/src/app/core/api/webSocketApi/web-socket-api.spec.ts
+++ b/src/app/core/api/webSocketApi/web-socket-api.spec.ts
@@ -4,6 +4,7 @@ import { TokenState } from '../../services/token.state';
 import { WebSocketApi } from './web-socket-api';
 import {
   WebSocketCloseCode,
+  WebSocketResponse,
   WebSocketSyncAckResponse,
   WebSocketSyncCompletedResponse,
   WebSocketSyncRequest,
@@ -73,13 +74,13 @@ describe('WebSocketApi', () => {
     );
     const req: WebSocketSyncRequest = { changes: [] };
     const ack: WebSocketSyncAckResponse = {
-      type: 'ack',
+      type: WebSocketResponse.ACK,
       operation_id: '1',
       status: 'started',
       created_at: 'now',
     };
     const completed: WebSocketSyncCompletedResponse = {
-      type: 'completed',
+      type: WebSocketResponse.COMPLETED,
       operation_id: '1',
       status: 'completed',
       completed_at: 'now',

--- a/src/app/core/api/webSocketApi/web-socket-api.ts
+++ b/src/app/core/api/webSocketApi/web-socket-api.ts
@@ -1,0 +1,126 @@
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { webSocketEnvironment } from '../../../../environments/environment';
+import { TokenState } from '../../services/token.state';
+import {
+  WebSocketCloseCode,
+  WebSocketSyncRequest,
+  WebSocketSyncResponse,
+} from './webSocket.model';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class WebSocketApi {
+  private readonly tokenState: TokenState = inject(TokenState);
+  private socket: WebSocket | null = null;
+
+  bulkSyncWebSocket(
+    request: WebSocketSyncRequest,
+  ): Observable<WebSocketSyncResponse> {
+    return new Observable(
+      (observer: import('rxjs').Observer<WebSocketSyncResponse>) => {
+        const accessToken: string | null = this.tokenState.getAccessToken();
+
+        if (!accessToken) {
+          observer.error(new Error('No access token available'));
+          return;
+        }
+
+        const wsUrl: string | undefined = webSocketEnvironment.webSocketUrl;
+        if (!wsUrl) {
+          observer.error(new Error('WebSocket URL not configured'));
+          return;
+        }
+
+        // Track completion state
+        let isCompleted: boolean = false;
+
+        this.socket = new WebSocket(
+          `${wsUrl}/sync/bulk/ws?token=${accessToken}`,
+        );
+
+        this.socket.onopen = (): void => {
+          console.error('[WebSocket] Connection opened');
+          console.error('[WebSocket] Sending request:', request);
+          this.socket!.send(JSON.stringify(request));
+        };
+
+        this.socket.onmessage = (event: MessageEvent): void => {
+          console.error('[WebSocket] Message received:', event.data);
+          try {
+            const response: WebSocketSyncResponse = JSON.parse(event.data);
+            observer.next(response);
+
+            if (response.type === 'completed' || response.type === 'error') {
+              console.error(
+                '[WebSocket] Completed or error received, closing...',
+              );
+              isCompleted = true;
+              observer.complete();
+            }
+          } catch (error) {
+            console.error('Failed to parse WebSocket response:', error);
+            isCompleted = true;
+            observer.error(
+              new Error(
+                `Invalid JSON response from server: ${error instanceof Error ? error.message : 'Unknown error'}`,
+              ),
+            );
+          }
+        };
+
+        this.socket.onerror = (): void => {
+          console.error('[WebSocket] Connection error');
+          if (!isCompleted) {
+            isCompleted = true;
+            observer.error(new Error('WebSocket connection error'));
+          }
+        };
+
+        this.socket.onclose = (event: CloseEvent): void => {
+          console.error(`[WebSocket] Connection closed (code: ${event.code})`);
+          if (isCompleted) return;
+
+          switch (event.code) {
+            case WebSocketCloseCode.MissingToken:
+              observer.error(new Error('Missing authentication token'));
+              break;
+            case WebSocketCloseCode.InvalidToken:
+              observer.error(new Error('Invalid authentication token'));
+              break;
+            case WebSocketCloseCode.InvalidPayload:
+              observer.error(new Error('Invalid request payload'));
+              break;
+            case WebSocketCloseCode.InternalError:
+              observer.error(new Error('Internal server error'));
+              break;
+            case WebSocketCloseCode.NormalClosure:
+              observer.complete();
+              break;
+            default:
+              observer.error(
+                new Error(`WebSocket closed with code: ${event.code}`),
+              );
+          }
+        };
+
+        // Cleanup function
+        return () => {
+          isCompleted = true;
+          if (this.socket && this.socket.readyState === WebSocket.OPEN) {
+            this.socket.close(WebSocketCloseCode.NormalClosure);
+          }
+          this.socket = null;
+        };
+      },
+    );
+  }
+
+  disconnect(): void {
+    if (this.socket) {
+      this.socket.close(WebSocketCloseCode.NormalClosure);
+      this.socket = null;
+    }
+  }
+}

--- a/src/app/core/api/webSocketApi/web-socket-api.ts
+++ b/src/app/core/api/webSocketApi/web-socket-api.ts
@@ -33,7 +33,6 @@ export class WebSocketApi {
           return;
         }
 
-        // Track completion state
         let isCompleted: boolean = false;
 
         this.socket = new WebSocket(
@@ -41,26 +40,19 @@ export class WebSocketApi {
         );
 
         this.socket.onopen = (): void => {
-          console.error('[WebSocket] Connection opened');
-          console.error('[WebSocket] Sending request:', request);
           this.socket!.send(JSON.stringify(request));
         };
 
         this.socket.onmessage = (event: MessageEvent): void => {
-          console.error('[WebSocket] Message received:', event.data);
           try {
             const response: WebSocketSyncResponse = JSON.parse(event.data);
             observer.next(response);
 
             if (response.type === 'completed' || response.type === 'error') {
-              console.error(
-                '[WebSocket] Completed or error received, closing...',
-              );
               isCompleted = true;
               observer.complete();
             }
           } catch (error) {
-            console.error('Failed to parse WebSocket response:', error);
             isCompleted = true;
             observer.error(
               new Error(
@@ -71,7 +63,6 @@ export class WebSocketApi {
         };
 
         this.socket.onerror = (): void => {
-          console.error('[WebSocket] Connection error');
           if (!isCompleted) {
             isCompleted = true;
             observer.error(new Error('WebSocket connection error'));
@@ -79,7 +70,6 @@ export class WebSocketApi {
         };
 
         this.socket.onclose = (event: CloseEvent): void => {
-          console.error(`[WebSocket] Connection closed (code: ${event.code})`);
           if (isCompleted) return;
 
           switch (event.code) {
@@ -105,7 +95,6 @@ export class WebSocketApi {
           }
         };
 
-        // Cleanup function
         return () => {
           isCompleted = true;
           if (this.socket && this.socket.readyState === WebSocket.OPEN) {

--- a/src/app/core/api/webSocketApi/webSocket.model.ts
+++ b/src/app/core/api/webSocketApi/webSocket.model.ts
@@ -2,33 +2,70 @@ export interface WebSocketSyncRequest {
   changes: WebSocketSyncChange[];
 }
 
+export enum WebSocketStatus {
+  STARTED = 'started',
+  COMPLETED = 'completed',
+  FAILED = 'failed',
+}
+
+export enum WebSocketCloseReason {
+  MISSING_TOKEN = 'Missing Access Token',
+  INVALID_TOKEN = 'Invalid Access Token',
+  INVALID_PAYLOAD = 'Invalid Payload',
+  INTERNAL_ERROR = 'Internal Server Error',
+  NORMAL_CLOSURE = 'Normal Closure',
+  INVALID_URL = 'Invalid or Malformed WebSocket URL',
+  CONNECTION_ERROR = 'WebSocket Connection Error',
+  SUCCESS_SYNC = 'WebSocket sync completed successfully',
+}
+
+export enum WebSocketResponse {
+  ACK = 'ack',
+  COMPLETED = 'completed',
+  ERROR = 'error',
+}
+
+export enum EntityType {
+  EXPENSE = 'expense',
+  GROUP = 'group',
+}
+
+export enum WebSocketSyncType {
+  CREATE = 'create',
+  UPDATE = 'update',
+  DELETE = 'delete',
+}
+
 export interface WebSocketSyncChange {
-  type: 'create' | 'update' | 'delete';
-  entity: 'expense' | 'group';
+  type:
+    | WebSocketSyncType.CREATE
+    | WebSocketSyncType.UPDATE
+    | WebSocketSyncType.DELETE;
+  entity: EntityType.EXPENSE | EntityType.GROUP;
   entity_id: string;
   data?: Record<string, unknown>;
   timestamp: string;
 }
 
 export interface WebSocketSyncAckResponse {
-  type: 'ack';
+  type: WebSocketResponse.ACK;
   operation_id: string;
-  status: 'started';
+  status: WebSocketStatus.STARTED;
   created_at: string;
 }
 
 export interface WebSocketSyncCompletedResponse {
-  type: 'completed';
+  type: WebSocketResponse.COMPLETED;
   operation_id: string;
-  status: 'completed';
+  status: WebSocketStatus.COMPLETED;
   completed_at: string;
   notifications: string[];
 }
 
 export interface WebSocketSyncErrorResponse {
-  type: 'error';
+  type: WebSocketResponse.ERROR;
   operation_id: string;
-  status: 'failed';
+  status: WebSocketStatus.FAILED;
   error: string;
 }
 

--- a/src/app/core/api/webSocketApi/webSocket.model.ts
+++ b/src/app/core/api/webSocketApi/webSocket.model.ts
@@ -1,0 +1,46 @@
+export interface WebSocketSyncRequest {
+  changes: WebSocketSyncChange[];
+}
+
+export interface WebSocketSyncChange {
+  type: 'create' | 'update' | 'delete';
+  entity: 'expense' | 'group';
+  entity_id: string;
+  data?: Record<string, unknown>;
+  timestamp: string;
+}
+
+export interface WebSocketSyncAckResponse {
+  type: 'ack';
+  operation_id: string;
+  status: 'started';
+  created_at: string;
+}
+
+export interface WebSocketSyncCompletedResponse {
+  type: 'completed';
+  operation_id: string;
+  status: 'completed';
+  completed_at: string;
+  notifications: string[];
+}
+
+export interface WebSocketSyncErrorResponse {
+  type: 'error';
+  operation_id: string;
+  status: 'failed';
+  error: string;
+}
+
+export type WebSocketSyncResponse =
+  | WebSocketSyncAckResponse
+  | WebSocketSyncCompletedResponse
+  | WebSocketSyncErrorResponse;
+
+export enum WebSocketCloseCode {
+  MissingToken = 4401,
+  InvalidToken = 4403,
+  InvalidPayload = 4400,
+  InternalError = 1011,
+  NormalClosure = 1000,
+}

--- a/src/app/core/services/network-status.service.ts
+++ b/src/app/core/services/network-status.service.ts
@@ -51,10 +51,10 @@ export class NetworkStatusService {
         distinctUntilChanged(),
         debounceTime(100),
       )
-      .subscribe((isOnline: boolean) => {
-        setIsOnline(isOnline);
+      .subscribe((isOnlineStatus: boolean) => {
+        setIsOnline(isOnlineStatus);
 
-        if (isOnline) {
+        if (isOnlineStatus) {
           this.checkBackendHealth();
         } else {
           setIsBackendReachable(false);
@@ -64,14 +64,14 @@ export class NetworkStatusService {
 
   private startPeriodicCheck(): void {
     this.checkInterval = setInterval(() => {
-      if (isOnline()) {
+      if (this.isOnline()) {
         this.checkBackendHealth();
       }
     }, 30000);
   }
 
   async checkBackendHealth(): Promise<boolean> {
-    if (!isOnline()) {
+    if (!this.isOnline()) {
       setIsBackendReachable(false);
       return false;
     }

--- a/src/environments/environment.model.ts
+++ b/src/environments/environment.model.ts
@@ -1,5 +1,7 @@
 export interface Environment {
   production: boolean;
-  apiUrl: string;
+  apiUrl?: string;
   port?: number;
+  webSocketUrl?: string;
+  webSocketPort?: number;
 }

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -7,3 +7,11 @@ export const environment: Environment = {
     return `http://localhost:${this.port}/api/v1`;
   },
 };
+
+export const webSocketEnvironment: Environment = {
+  production: false,
+  webSocketPort: 8000,
+  get webSocketUrl() {
+    return `ws://localhost:${this.webSocketPort}/api/v2`;
+  },
+};


### PR DESCRIPTION
Summary
- Add a WebSocket API (WebApi) asyncWebSocket method, disconnect helper, proper event (onopen, onmessage, onerror, onclose), teardown/ behavior, and mapping of server close codes to clear errors or completion.
- Introduce WebSocket model types for sync requests, changes, and responses to standardize bulk sync payloads.
- Make environment.apiUrl optional and add optional webSocketUrl and webSocketPort for runtime WebSocket configuration.
- Add WebSocket-based background bulk sync with HTTP fallback: implement syncViaWebSocket, wire effect to auto-start sync when online/backend reachable, prefer WebSocket path, and fall back to HTTP on failure while showing warning and ensuring queue cleared and indicators stopped.
- Remove verbose console.error debug logs from the WebSocket API.

Motivation
- Enable real-time bulk synchronization over WebSocket with robust fallback to existing HTTP sync and clearer error handling.

Test plan
- Verify WebSocket sync succeeds and acknowledges/handles completed/error responses.
- Confirm fallback to HTTP sync on WebSocket failure, with warning toast and cleared queue.
- Ensure environment upgrades remain backward compatible when webSocket config is absent.
- Confirm teardown/close behavior and reduced console noise.