### PR TITLE
actor: rename project from ToDoApp to ExpenseTrackingApp

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -3,7 +3,7 @@
   "version": 1,
   "newProjectRoot": "projects",
   "projects": {
-    "ToDoApp": {
+    "ExpenseTrackingApp": {
       "projectType": "application",
       "schematics": {
         "@schematics/angular:component": {
@@ -65,10 +65,10 @@
           "builder": "@angular/build:dev-server",
           "configurations": {
             "production": {
-              "buildTarget": "ToDoApp:build:production"
+              "buildTarget": "ExpenseTrackingApp:build:production"
             },
             "development": {
-              "buildTarget": "ToDoApp:build:development"
+              "buildTarget": "ExpenseTrackingApp:build:development"
             }
           },
           "defaultConfiguration": "development"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "to-do-app",
+  "name": "expense-tracking-app",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "to-do-app",
+      "name": "expense-tracking-app",
       "version": "0.0.0",
       "dependencies": {
         "@angular/animations": "^20.1.2",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "to-do-app",
+  "name": "expense-tracking-app",
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "ToDoApp",
-  "short_name": "ToDoApp",
+  "name": "ExpenseTrackingApp",
+  "short_name": "ExpenseTrackingApp",
   "display": "standalone",
   "scope": "./",
   "start_url": "./",


### PR DESCRIPTION
Update app identity and configuration to reflect the new project
name "ExpenseTrackingApp". Change manifest title and short name for
PWA to ExpenseTrackingApp. Update Angular workspace settings so the
project key and build targets reference ExpenseTrackingApp. Rename
package identifiers in package.json and package-lock.json to
expense-tracking-app to match the new name and ensure tooling and
publish metadata are consistent.

This keeps project naming consistent across manifest, Angular
configuration, and package metadata to avoid build and packaging
mismatches.